### PR TITLE
fix: stop generating empty single pages for books

### DIFF
--- a/site/content/books/_index.md
+++ b/site/content/books/_index.md
@@ -1,0 +1,8 @@
+---
+title: Books library
+cascade:
+  - _target:
+      kind: page
+    _build:
+      render: link
+---

--- a/site/layouts/sitemap.xml
+++ b/site/layouts/sitemap.xml
@@ -2,6 +2,8 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range .Pages }}
+    {{/* Книги рендерятся как render:link (без HTML-файла) — в sitemap им не место */}}
+    {{ if and (eq .Kind "page") (eq .Section "books") }}{{ continue }}{{ end }}
     <url>
       <loc>{{ .Permalink }}</loc>
       {{ if not .Lastmod.IsZero }}


### PR DESCRIPTION
Closes #19

## Problem
Each book is a leaf file with only front matter (cover, author, genre, status) and an empty body. Nothing links to a book's own page, yet Hugo still rendered an **empty single page per book** — crawlable and listed in `sitemap.xml`.

## Fix
- `content/books/_index.md` — section cascade sets `render: link` on book pages only (`_target: kind: page`). Hugo writes **no HTML file** for them, but keeps their permalink, so they stay in `site.Taxonomies` and the genre/status shelf filters keep working.
- `layouts/sitemap.xml` — skip `kind=page` pages in the `books` section so no dead URLs are advertised.

## Verification (`hugo --minify`)
- Empty book single files on disk: **0** (was one per book)
- Book singles in sitemap: **0**
- `/books/` list: builds, 259 covers intact
- `/genre/*` and `/status/*` term pages: build correctly with their books

Considered `render: never` (cleans sitemap but drops books from `site.Taxonomies`, breaking filters) and plain `render: link` (keeps taxonomies but leaves dead URLs in the sitemap); this combination avoids both downsides.