### PR TITLE
ci: add build check (and fix the deprecated keys it caught)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,40 @@
+name: Build
+
+# Проверяет, что сайт вообще собирается, до того как изменения попадут в main
+# и сервер дёрнет deploy.yaml. Падение Hugo/pagefind тут блокирует merge.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  HUGO_VERSION: 0.163.3
+  PAGEFIND_VERSION: 1.5.2
+
+jobs:
+  build:
+    name: Build site
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Hugo (extended)
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: ${{ env.HUGO_VERSION }}
+          extended: true
+
+      - name: Build with Hugo
+        working-directory: site
+        run: hugo --minify --gc
+
+      - name: Build search index (pagefind)
+        working-directory: site
+        run: npx -y pagefind@${{ env.PAGEFIND_VERSION }} --site public --output-subdir _pagefind --force-language all

--- a/site/content/books/_index.md
+++ b/site/content/books/_index.md
@@ -1,8 +1,8 @@
 ---
 title: Books library
 cascade:
-  - _target:
+  - target:
       kind: page
-    _build:
+    build:
       render: link
 ---


### PR DESCRIPTION
## Why
Deploy is SSH-based (`deploy.yaml`): a push to `main` makes the server pull and rebuild Hugo in Docker. There is **no build validation on GitHub**, so a broken site is only discovered at deploy time.

## What
A `Build` workflow that runs on every **pull request** and **push to main** (plus manual dispatch), reproducing the production pipeline from the `Makefile`:
1. `hugo --minify --gc`
2. `pagefind` over `public/`

Pinned to production versions: **Hugo 0.163.3 extended**, **pagefind 1.5.2**.

## It immediately caught a real bug
On its first run the check **failed** — and correctly so. `content/books/_index.md` (merged in #35) used the `_target` / `_build` front-matter keys, which Hugo renamed/removed in 0.145–0.156. A local `extended+withdeploy` binary silently accepts them, but a clean `gohugoio` binary (CI, and the deploy container) **errors out** — so production builds were broken.

This PR also fixes that: renames to the current `target` / `build` keys. Output is unchanged — no book single pages, genre/status taxonomies and the shelf intact, sitemap clean.

## Verified
- New keys: local build emits **no deprecation/error**, 0 book singles, genre=9 / status=3 term pages, 259 covers on `/books/`, 0 book singles in sitemap.
- This PR's own CI run validates the fix on a clean Hugo.