### PR TITLE
Make the RSS feed full-fledged (#6)

### DIFF
--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -62,6 +62,10 @@ weight = 2
 [outputs]
 home = ["HTML", "RSS"]
 
+[services]
+[services.rss]
+limit = 30
+
 [sitemap]
 changefreq = "monthly"
 priority = 0.5

--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -102,12 +102,14 @@
     />
 
     <!-- RSS -->
-    <link
-      rel="alternate"
-      type="application/rss+xml"
-      href="{{ .Site.BaseURL }}index.xml"
-      title="{{ .Site.Title }} RSS Feed"
-    />
+    {{ with .OutputFormats.Get "RSS" }}
+      <link
+        rel="alternate"
+        type="application/rss+xml"
+        href="{{ .Permalink }}"
+        title="{{ $.Site.Title }} RSS Feed"
+      />
+    {{ end }}
 
     <!-- External Libraries -->
     <link

--- a/site/layouts/_default/rss.xml
+++ b/site/layouts/_default/rss.xml
@@ -1,30 +1,39 @@
 {{- $pctx := . -}}
 {{- if .IsHome -}}{{ $pctx = .Site }}{{- end -}}
 {{- $pages := $pctx.RegularPages -}}
-{{- $limit := .Site.Config.Services.RSS.Limit -}}
-{{- if ge $limit 1 -}}
-{{- $pages = $pages | first $limit -}}
+{{/* На общем фиде главной не показываем книги — это список чтения (render:link, без контента), а не записи */}}
+{{- if .IsHome -}}
+  {{- $pages = where $pages "Section" "!=" "books" -}}
 {{- end -}}
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+{{/* Служебная страница поиска — не запись, в фид не нужна */}}
+{{- $pages = where $pages "Layout" "!=" "search" -}}
+{{- $pages = $pages.ByDate.Reverse -}}
+{{- $limit := .Site.Config.Services.RSS.Limit -}}
+{{- if ge $limit 1 -}}{{- $pages = $pages | first $limit -}}{{- end -}}
+{{ printf "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" | safeHTML }}
+<rss version="2.0"
+     xmlns:atom="http://www.w3.org/2005/Atom"
+     xmlns:content="http://purl.org/rss/1.0/modules/content/"
+     xmlns:dc="http://purl.org/dc/elements/1.1/">
   <channel>
-    <title>{{ .Site.Title }}</title>
+    <title>{{ .Site.Title }}{{ if not .IsHome }} — {{ .Title }}{{ end }}</title>
     <link>{{ .Permalink }}</link>
-    <description>Последние обновления в блоге alchemmist</description>
+    <description>Последние записи в блоге alchemmist</description>
     <generator>Hugo {{ hugo.Version }}</generator>
-    <language>ru</language>
+    <language>{{ .Site.Language.Lang }}</language>
     {{ with .Site.Copyright }}<copyright>{{ . }}</copyright>{{ end }}
-    <lastBuildDate>{{ now.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
-    <atom:link href="{{ .Permalink }}" rel="self" type="application/rss+xml" />
+    {{ with .OutputFormats.Get "RSS" }}<atom:link href="{{ .Permalink }}" rel="self" type="application/rss+xml" />{{ end }}
+    <lastBuildDate>{{ range first 1 $pages }}{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}{{ else }}{{ now.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}{{ end }}</lastBuildDate>
     {{ range $pages }}
     <item>
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      {{ with .Params.author }}<dc:creator>{{ if reflect.IsSlice . }}{{ delimit . ", " }}{{ else }}{{ . }}{{ end }}</dc:creator>{{ else }}<dc:creator>alchemmist</dc:creator>{{ end }}
       <guid>{{ .Permalink }}</guid>
-      <description>{{ .Summary | html }}</description>
-      {{ if .Params.tags }}
-      <category>{{ delimit .Params.tags ", " }}</category>
-      {{ end }}
+      {{ with .Summary | plainify | htmlUnescape }}<description>{{ . | htmlEscape }}</description>{{ end }}
+      <content:encoded>{{ printf "<![CDATA[%s]]>" .Content | safeHTML }}</content:encoded>
+      {{ range .Params.tags }}<category>{{ . }}</category>{{ end }}
     </item>
     {{ end }}
   </channel>


### PR DESCRIPTION
Closes #6.

### What was broken
The feed existed but wasn't usable:
- the home `/index.xml` was dominated by **books** — `render:link` reading-list stubs with an empty `<description/>`, not actual posts;
- `<atom:link rel="self">` pointed at the homepage instead of the feed itself;
- `<language>` was hardcoded to `ru` even in the English feed;
- there was no full content — only a truncated summary.

### What changed
- exclude the `books` section and the service `search` page from the home feed;
- sort by date + a configurable item limit (`services.rss.limit = 30`);
- full post HTML via `<content:encoded>` (CDATA) plus a plain-text `<description>`; added the `content`/`dc` namespaces and `<dc:creator>`;
- fixed `atom:self` (now points at the feed) and made `<language>` dynamic — every per-language feed is now correct;
- autodiscovery `<link rel="alternate">` via `.OutputFormats` — readers pick the relevant feed (home → aggregate, section → section feed).

### Verification
- `hugo --gc` builds with no errors;
- `/index.xml` and `/ru/index.xml` are well-formed (`xmllint --noout` ✓);
- 0 books, 0 empty descriptions, 0 service pages in the feed; full content present.
