### PR TITLE
Show shortcut hint on hover over section buttons (#29)

### DIFF
--- a/site/assets/main.js
+++ b/site/assets/main.js
@@ -256,6 +256,42 @@ const shortcutsMap = Object.fromEntries(
   shortcuts.filter((s) => s.url).map((s) => [s.key, s.url]),
 );
 
+// Подсказка шортката при наведении на кнопки разделов (#29).
+// Сопоставляем ссылки навигации с шорткатами по их URL и вешаем бейдж с клавишей.
+const normalizePath = (path) => {
+  try {
+    path = new URL(path, window.location.origin).pathname;
+  } catch (e) {
+    /* оставляем как есть, если href не парсится */
+  }
+  return path === "/" ? "/" : path.replace(/\/$/, "");
+};
+
+const urlToShortcutKey = Object.fromEntries(
+  shortcuts
+    .filter((s) => s.url)
+    .map((s) => [normalizePath(s.url), s.key]),
+);
+
+function decorateShortcutHints() {
+  // Только навигационные кнопки разделов, не ссылки в тексте.
+  document.querySelectorAll(".side-menu a, .link a").forEach((a) => {
+    const href = a.getAttribute("href");
+    if (!href) return;
+    const key = urlToShortcutKey[normalizePath(href)];
+    if (!key) return;
+    a.classList.add("has-shortcut");
+    a.dataset.shortcut = key;
+    a.setAttribute("title", `Shortcut: ${key}`);
+  });
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", decorateShortcutHints);
+} else {
+  decorateShortcutHints();
+}
+
 const overlay = document.getElementById("shortcut-overlay");
 const modal = document.getElementById("shortcut-modal");
 const shortcutList = document.getElementById("shortcut-list");

--- a/site/assets/style.css
+++ b/site/assets/style.css
@@ -1967,6 +1967,33 @@ pre code * .err {
   font-size: 18px;
 }
 
+/* Подсказка клавиши-шортката при наведении на кнопку раздела (#29) */
+.side-menu a.has-shortcut,
+.link a.has-shortcut {
+  position: relative;
+}
+.side-menu a.has-shortcut::after,
+.link a.has-shortcut::after {
+  content: attr(data-shortcut);
+  display: inline-block;
+  margin-left: 0.5em;
+  padding: 0 0.4em;
+  border: 1px solid currentColor;
+  border-radius: 4px;
+  font-family: monospace;
+  font-size: 0.75em;
+  line-height: 1.5;
+  vertical-align: middle;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+.side-menu a.has-shortcut:hover::after,
+.side-menu a.has-shortcut:focus-visible::after,
+.link a.has-shortcut:hover::after,
+.link a.has-shortcut:focus-visible::after {
+  opacity: 0.6;
+}
+
 .overlay {
   position: fixed;
   top: 0;


### PR DESCRIPTION
Closes #29.

The shortcut keys that jump between sections (`h`, `a`, `e`, `c`, `b`, `p`, `u`) were only discoverable via the `?` help modal. This surfaces each one directly on its navigation button.

### What changed
- `main.js`: build a URL → key map from the existing `shortcuts` array and decorate each section nav link (`.side-menu a`, `.link a`) whose href matches with a `data-shortcut` attribute and a `title` fallback. Scoped to nav links so in-text links are never touched.
- `style.css`: render the key as a small badge that fades in on `:hover`/`:focus-visible` of the button.

### Notes
- `/search` (Ctrl+k only) and any link without a mapped shortcut get no badge — verified the URL matching against the real nav hrefs.
- No new data source: the badge reuses the same `shortcuts` list that powers the `?` modal and the key handler, so they can't drift apart.
