### PR TITLE
Fix code blocks without a specified language (#25)

### DIFF
--- a/site/assets/style.css
+++ b/site/assets/style.css
@@ -411,15 +411,29 @@ pre code .tab::selection {
   color: rgba(0, 0, 0, 0);
 }
 
+/* Блоки без указанного языка (#25) рендерятся как <pre><code>текст</code></pre>
+   без дочерних span — поэтому шрифт/выравнивание вешаем и на сам pre code,
+   иначе такой текст наследует серифный центрированный article *. */
+pre code,
 pre code * {
   font-family: "NerdFontsSymbols Nerd Font", "Computer Modern Typewriter";
-  font-size: 0.96em;
   line-height: 1.2;
   text-align: left;
 }
 
+/* Размер задаём на самом code (нужно для блоков без языка, где нет дочерних
+   span); у потомков 1em, чтобы em не умножался дважды и язык-блоки не меняли
+   размер. */
+pre code {
+  font-size: 0.96em;
+}
+
+pre code * {
+  font-size: 1em;
+}
+
 @media (max-width: 650px) {
-  pre code * {
+  pre code {
     font-size: 1em;
   }
 }


### PR DESCRIPTION
Closes #25.

### Root cause
A fenced block **with** a language renders as `<pre class="chroma"><code><span>…</span></code></pre>` — the text lives in child `<span>`s. A block **without** a language renders as `<pre><code>text</code></pre>` — the text sits directly in `<code>`, with no child elements.

The code styling (monospace font, size, line-height, `text-align: left`) was applied only to `pre code *` (the children). Language-less blocks have no such children, so their text fell through to `article *` — serif font, centered, body size.

### Fix
- Apply `font-family` / `line-height` / `text-align` to `pre code` itself, not just `pre code *`.
- Avoid double `em` multiplication on highlighted blocks: `font-size: 0.96em` on `pre code`, `1em` on the children. Highlighted blocks keep their exact current size (17.28px) and language-less blocks now match it.

### Verification
- Reproduced with a test article containing a `python` block and a bare ```` ``` ```` block; confirmed the two render paths (`<code><span>` vs `<code>text`).
- Compiled CSS (clean build, cache cleared) shows the intended cascade: `pre code,pre code *{…monospace;line-height;text-align}` + `pre code{font-size:.96em}` + `pre code *{font-size:1em}`.
- No browser screenshot available in this environment; verified via the rendered HTML structure and the resulting CSS cascade rather than a visual diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the display of plain text code blocks so they scale more consistently across screen sizes.
  * Fixed font sizing issues that could cause language-less code blocks to appear incorrectly sized or double-scaled on smaller devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->