### PR TITLE
Show result images in pagefind search (#13)

### DIFF
--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -123,6 +123,18 @@
     {{ block "head" . }}{{ end }}
   </head>
   <body>
+    <!-- Pagefind: картинка для результатов поиска (#13). Pagefind 1.x не
+         достаёт картинки сам и читает data-pagefind-meta только из <body>,
+         поэтому отдаём ему OG-карточку страницы явно скрытым элементом —
+         иначе showImages в поиске показывать нечего. -->
+    <span
+      data-pagefind-meta="image[data-src]"
+      data-src="{{ $ogImage }}"
+    ></span>
+    <span
+      data-pagefind-meta="image_alt[data-alt]"
+      data-alt="{{ .Title }}"
+    ></span>
     <button id="report-typo">Report</button>
     <div id="shortcut-overlay"></div>
     <div id="shortcut-modal">

--- a/site/layouts/_default/search.html
+++ b/site/layouts/_default/search.html
@@ -11,7 +11,7 @@
       languages: ["ru", "en"],
       locale: "en",
       element: "#search",
-      showImages: false,
+      showImages: true,
       autoFocus: true,
       translations: {
         placeholder: "Search",


### PR DESCRIPTION
Closes #13.

### Why the flag alone isn't enough
Pagefind 1.x does **not** auto-extract images from pages. With no image metadata in the index, `showImages: true` has nothing to render — which is why even the modal search (already `showImages: true`) showed no images. I confirmed this directly: before the change, **0** indexed fragments carried any image.

### Fix
- Expose a per-page image to Pagefind via `data-pagefind-meta`, reusing the existing **OG card** (the generated title card for content pages, `preview.png` for list/taxonomy pages) plus the page title as alt text.
- Pagefind only reads `data-pagefind-meta` from inside `<body>` (not `<head>`), so the tags are placed in the body as empty `<span>`s.
- Flip `showImages` to `true` on the `/search` page (the modal already had it on, now consistent).

### Verification
- Built the site + ran Pagefind 1.5.2, then decoded the fragment index: **301/302** indexed pages now carry `meta.image` + `meta.image_alt` (the one without is a no-image page).
- Every referenced OG png exists in the build output (75 generated cards + `preview.png`).
- `/search` compiled output has `showImages: true`.
- No browser was available here to screenshot the rendered thumbnails; verification is against the Pagefind index contents and the build artifacts.
