### PR TITLE
Make a poem fill the first screen on poetry pages (#24)

### DIFF
--- a/site/assets/style.css
+++ b/site/assets/style.css
@@ -527,6 +527,15 @@ p code * {
   flex-direction: column;
 }
 
+/* Стихотворение занимает первый экран целиком, по центру по вертикали (#24).
+   Комментарии и футер уходят за сгиб — открываются скроллом. svh, чтобы на
+   мобильных адресная строка не выталкивала комментарии в зону видимости. */
+.verse-container .poetry {
+  min-height: calc(100vh - 2rem);
+  min-height: calc(100svh - 2rem);
+  justify-content: center;
+}
+
 .verse-container #remark42 {
   width: 100%;
 }


### PR DESCRIPTION
Closes #24.

On poetry pages a short poem left the comments (remark42) and footer right under it on the same screen. This gives the poem its own first screen — comments and footer move below the fold and appear on scroll.

### Change
- `min-height: calc(100svh - 2rem)` on `.verse-container .poetry`, vertically centered. `svh` (with a `vh` fallback) keeps the comments below the fold even when the mobile address bar is visible.
- Long poems are unaffected — they already exceed the viewport.

### Verification (real browser, production build)
Measured `getBoundingClientRect` on a built+served site (not the dev server, which drops styles via SRI):

| viewport | poem | poem block | comments top | below fold? |
|---|---|---|---|---|
| 1280×800 desktop | short ("Турка") | 768px, centered (+56px) | 906px | ✅ |
| 1280×800 desktop | long ("Между") | 1604px content | 1742px | ✅ |
| 390×844 mobile | short ("Турка") | 812px, centered (+16px) | 910px | ✅ |

In every case the comments and footer sit below the fold; for short poems the poem is centered on the first screen.
