### PR TITLE
Lazy-load comments on poetry pages (#33)

### DIFF
--- a/site/layouts/partials/remark42-lazy.html
+++ b/site/layouts/partials/remark42-lazy.html
@@ -1,0 +1,57 @@
+{{/* Лениво подгружает комментарии remark42 — embed.js загружается только
+     когда блок #remark42 приближается к вьюпорту. Иначе на загрузке страницы
+     виджет дёргает layout (несколько сдвигов в первые ~600мс) — #33.
+     Требует <div id="remark42"></div> где-то на странице. */}}
+<script>
+  window.remark_config = {
+    host: "https://remark42.alchemmist.xyz",
+    site_id: "alchemmist",
+    components: ["embed"],
+    no_footer: true,
+    simpe_view: true,
+  };
+
+  (function () {
+    function loadRemark() {
+      if (window.__remark42Loaded) return;
+      window.__remark42Loaded = true;
+      var s = document.createElement("script");
+      s.src = "https://remark42.alchemmist.xyz/web/embed.js";
+      s.defer = true;
+      document.head.appendChild(s);
+    }
+
+    function init() {
+      var el = document.getElementById("remark42");
+      if (!el) return;
+      // Нет IntersectionObserver — грузим сразу, поведение как раньше.
+      if (!("IntersectionObserver" in window)) {
+        loadRemark();
+        return;
+      }
+      var io = new IntersectionObserver(
+        function (entries) {
+          if (
+            entries.some(function (e) {
+              return e.isIntersecting;
+            })
+          ) {
+            io.disconnect();
+            loadRemark();
+          }
+        },
+        // rootMargin 0 — грузим строго когда блок реально входит во вьюпорт.
+        // Любой положительный нижний отступ растянул бы корень вниз и заставил
+        // комментарии под сгибом грузиться уже на старте — ровно тот лаг (#33).
+        { rootMargin: "0px" },
+      );
+      io.observe(el);
+    }
+
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", init);
+    } else {
+      init();
+    }
+  })();
+</script>

--- a/site/layouts/poetry/single.html
+++ b/site/layouts/poetry/single.html
@@ -14,14 +14,5 @@
 {{ end }} {{ define "head" }}
 <meta data-pagefind-filter="Language[lang]" lang="{{.Language.Label}}" />
 
-<script>
-  window.remark_config = {
-    host: "https://remark42.alchemmist.xyz",
-    site_id: "alchemmist",
-    components: ["embed"],
-    no_footer: true,
-    simpe_view: true,
-  };
-</script>
-<script src="https://remark42.alchemmist.xyz/web/embed.js" defer></script>
+{{ partial "remark42-lazy.html" . }}
 {{ partial "connect-medium-zoom.html" }} {{ end }}


### PR DESCRIPTION
Closes #33.

The remark42 comments loaded eagerly on every poetry page. The iframe appeared ~200ms into load and shifted the layout several times in the first ~600ms — that's the juddering on load.

### Change
- New reusable partial `remark42-lazy.html`: keeps `remark_config`, but loads `embed.js` only when the `#remark42` block scrolls into view via `IntersectionObserver` (`rootMargin: 0px`, so a block below the fold does **not** trigger on initial load). Falls back to eager load if `IntersectionObserver` is missing.
- Poetry single page now uses the partial instead of the inline eager `<script src=…embed.js>`.

### Verification (real browser, production build)
| | eager (before) | lazy (after) |
|---|---|---|
| embed.js on initial load | injected | **not injected** |
| iframe on initial load | present (~200ms) | **absent** |
| layout shift on load | CLS 0.032, 3 shifts | **CLS 0, 0 shifts** |
| comments after scrolling into view | — | load in ~150ms ✅ |

### Note
The same eager pattern exists in `articles`, `essays`, and `moss/logo-symbolism` single layouts. This PR only touches poetry (the reported page); they can adopt the new partial in a follow-up.
