### PR TITLE
Optimize content images: resize + WebP + responsive srcset (#1)

### DIFF
--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -76,3 +76,32 @@ filename = "sitemap.xml"
 # Разрешаем любой тип контента — возвращаем прежнее поведение.
 [security]
 allowContent = ['.']
+
+# Монтируем static/images ещё и в assets/images, чтобы Hugo мог обрабатывать
+# контентные картинки (ресайз/WebP/srcset) через resources.Get в render hook
+# (#1). Объявление mounts заменяет дефолтные — поэтому перечисляем их все.
+[module]
+[[module.mounts]]
+source = "content"
+target = "content"
+[[module.mounts]]
+source = "data"
+target = "data"
+[[module.mounts]]
+source = "layouts"
+target = "layouts"
+[[module.mounts]]
+source = "i18n"
+target = "i18n"
+[[module.mounts]]
+source = "archetypes"
+target = "archetypes"
+[[module.mounts]]
+source = "assets"
+target = "assets"
+[[module.mounts]]
+source = "static"
+target = "static"
+[[module.mounts]]
+source = "static/images"
+target = "assets/images"

--- a/site/layouts/_default/_markup/render-image.html
+++ b/site/layouts/_default/_markup/render-image.html
@@ -1,0 +1,7 @@
+{{- /* Контентные картинки из markdown оптимизируются через общий партиал (#1):
+       ресайз/WebP/srcset/lazy + data-zoom-src. GIF/SVG/удалённые — как есть. */ -}}
+{{- partial "responsive-img.html" (dict
+  "src" .Destination
+  "alt" .Text
+  "title" .Title
+) -}}

--- a/site/layouts/partials/responsive-img.html
+++ b/site/layouts/partials/responsive-img.html
@@ -1,0 +1,56 @@
+{{- /* Адаптивная картинка с оптимизацией (#1). Принимает dict:
+       src (обяз.), alt, title, class, id, loading (по умолч. lazy), sizes.
+       Локальные растры (png/jpg/webp) режет под ширину показа, отдаёт WebP +
+       srcset + width/height (против CLS) + data-zoom-src покрупнее для
+       medium-zoom. GIF/SVG/удалённые — отдаёт как есть. */ -}}
+{{- $src := .src -}}
+{{- $alt := .alt | default "" -}}
+{{- $title := .title -}}
+{{- $class := .class -}}
+{{- $id := .id -}}
+{{- $loading := .loading | default "lazy" -}}
+{{- $sizes := .sizes | default "(max-width: 760px) 92vw, 700px" -}}
+{{- $ext := lower (strings.TrimPrefix "." (path.Ext $src)) -}}
+{{- $isLocal := and (hasPrefix $src "/") (not (hasPrefix $src "//")) -}}
+{{- $raster := in (slice "png" "jpg" "jpeg" "webp") $ext -}}
+{{- $res := "" -}}
+{{- if and $isLocal $raster -}}
+  {{- $path := strings.TrimPrefix "/" $src -}}
+  {{- with (resources.Get $path) -}}
+    {{- $res = . -}}
+  {{- else -}}
+    {{- with (resources.Get (replace $path "%20" " ")) -}}{{- $res = . -}}{{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if $res -}}
+  {{- $widths := slice 360 720 1080 1440 -}}
+  {{- $variants := slice -}}
+  {{- range $w := $widths -}}
+    {{- if le $w $res.Width -}}
+      {{- $variants = $variants | append ($res.Resize (printf "%dx webp q80" $w)) -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if not $variants -}}
+    {{- $variants = $variants | append ($res.Resize (printf "%dx webp q80" $res.Width)) -}}
+  {{- end -}}
+  {{- $largest := index $variants (sub (len $variants) 1) -}}
+  {{- $fallback := index $variants 0 -}}
+  {{- range $v := $variants -}}{{- if le $v.Width 760 -}}{{- $fallback = $v -}}{{- end -}}{{- end -}}
+  {{- $srcset := slice -}}
+  {{- range $v := $variants -}}{{- $srcset = $srcset | append (printf "%s %dw" $v.RelPermalink $v.Width) -}}{{- end -}}
+  <img
+    src="{{ $fallback.RelPermalink }}"
+    {{- if gt (len $variants) 1 }} srcset="{{ delimit $srcset ", " }}" sizes="{{ $sizes }}"{{ end }}
+    width="{{ $fallback.Width }}"
+    height="{{ $fallback.Height }}"
+    {{- with $class }} class="{{ . }}"{{ end }}
+    {{- with $id }} id="{{ . }}"{{ end }}
+    alt="{{ $alt }}"
+    {{- with $title }} title="{{ . }}"{{ end }}
+    loading="{{ $loading }}"
+    decoding="async"
+    data-zoom-src="{{ $largest.RelPermalink }}"
+  />
+{{- else -}}
+  <img src="{{ $src }}"{{ with $class }} class="{{ . }}"{{ end }}{{ with $id }} id="{{ . }}"{{ end }} alt="{{ $alt }}"{{ with $title }} title="{{ . }}"{{ end }} loading="{{ $loading }}" decoding="async" />
+{{- end -}}

--- a/site/layouts/teach/eosp.html
+++ b/site/layouts/teach/eosp.html
@@ -65,12 +65,7 @@
         or (in (lower .Name) ".jpg") (in (lower .Name) ".jpeg") (in (lower
         .Name) ".png") (in (lower .Name) ".webp") }}
         <div class="masonry-item">
-          <img
-            src="/images/eosp/{{ .Name }}"
-            alt="{{ .Name }}"
-            data-zoom
-            loading="lazy"
-          />
+          {{ partial "responsive-img.html" (dict "src" (printf "/images/eosp/%s" .Name) "alt" .Name) }}
         </div>
         {{ end }} {{ end }}
       </div>

--- a/site/layouts/teach/individual-education.html
+++ b/site/layouts/teach/individual-education.html
@@ -5,7 +5,7 @@
   <article>
     <h2>Обо мне</h2>
     <div id="about-me-box">
-      <img class="medium-zoom-image" src="/images/me2.png" id="me-photo" />
+      {{ partial "responsive-img.html" (dict "src" "/images/me2.png" "id" "me-photo" "class" "medium-zoom-image" "alt" "Антон") }}
       <p>
         Меня зовут Антон, я практикующий разработчик и студент Центрального
         Университета на направлении «Математика и компьютерные науки» (2028).
@@ -49,8 +49,8 @@
       прохождения на платформе:
     </p>
     <div id="teach-preview">
-      <img src="/images/teach1.png" />
-      <img src="/images/teach2.png" />
+      {{ partial "responsive-img.html" (dict "src" "/images/teach1.png" "alt" "Превью платформы") }}
+      {{ partial "responsive-img.html" (dict "src" "/images/teach2.png" "alt" "Превью платформы") }}
     </div>
     <h2>Что будете делать вы</h2>
     <p>

--- a/site/layouts/teach/list.html
+++ b/site/layouts/teach/list.html
@@ -16,8 +16,8 @@
         {{ if .Params.thumbnail }}
         <div class="lecture-thumb">
           <a href="{{ .RelPermalink }}">
-            <img src="{{ .Params.thumbnail }}" alt="{{ .Title }}"
-          /></a>
+            {{ partial "responsive-img.html" (dict "src" .Params.thumbnail "alt" .Title) }}
+          </a>
         </div>
         {{ end }}
         <div class="lecture-content">


### PR DESCRIPTION
Closes #1.

Content images were served straight from `static/` at full resolution — **119 MB** of rasters (49 files over 1 MB), 1500–2100px wide but displayed at ~700px, with no resize, WebP, or responsive sizing.

### Approach (Hugo-native, self-hosted — no third-party proxy)
- Mount `static/images` into `assets/images` (config) so Hugo can process the existing files in place — no file moves, originals stay reachable.
- New reusable `partials/responsive-img.html`: resizes a local raster to display-width variants (360/720/1080/1440, never upscaling), encodes **WebP q80**, emits `srcset` + `sizes`, sets `width`/`height` (against CLS), `loading="lazy"`, and a larger `data-zoom-src` for medium-zoom.
- A markdown image **render hook** (`_markup/render-image.html`) routes every content image through the partial.
- Converted the **teach** templates (eosp gallery, individual-education, lecture thumbnails) to the same partial.
- GIF / SVG / remote images pass through unchanged.

### Verification (real browser, production build)
| page | before | after |
|---|---|---|
| article `battery-degradation` (images) | ~2.75 MB | **18 KB**, all WebP, CLS 0 |
| one article image (720w default) | 2750 KB PNG | **17 KB** WebP |
| eosp gallery photo | ~1 MB JPG | **22–46 KB** WebP |

- No raw PNG/JPG fetched on the article; every `<img>` resolves to WebP via `srcset`.
- `#me-photo` keeps its `id` and 180px CSS sizing; gallery/zoom intact (`data-zoom-src` → 1440w variant).
- Generated WebP variants total ~15 MB across the whole site.

### Notes / possible follow-ups
- The original full-size files stay published (served from `static/`) so any direct links / external references keep working; browsers no longer fetch them. They could be pruned later if desired.
- **GIFs** (an 8 MB demo gif) are passed through untouched — animated GIF → MP4 is a separate change.
- **SVGs** total only ~125 KB; svgo optimization is low-value and skipped here.
- Book-cover images are mostly remote URLs (rendered by templates, not this hook) and are out of scope.
