### PR TITLE
Fix stretched, oversized images in poems (image regression)

### DIFF
--- a/site/assets/style.css
+++ b/site/assets/style.css
@@ -273,6 +273,15 @@ article img {
   height: auto;
 }
 
+/* Контентные картинки (render hook / партиал, #1): всегда сохраняем пропорции.
+   Без height:auto явная высота из width/height-атрибутов растягивала картинки
+   там, где нет правила article img (например в стихах). max-width:100% — чтобы
+   заданная ширина (![|400]) уменьшалась на узких экранах. */
+.content-img {
+  max-width: 100%;
+  height: auto;
+}
+
 article img[src$=".gif"] {
   border-radius: 0.5rem;
   box-shadow: 0 0 20px rgba(0, 0, 0, 0.15);

--- a/site/layouts/_default/_markup/render-image.html
+++ b/site/layouts/_default/_markup/render-image.html
@@ -1,7 +1,19 @@
-{{- /* Контентные картинки из markdown оптимизируются через общий партиал (#1):
-       ресайз/WebP/srcset/lazy + data-zoom-src. GIF/SVG/удалённые — как есть. */ -}}
+{{- /* Контентные картинки из markdown оптимизируются через общий партиал (#1).
+       Поддерживаем obsidian-синтаксис размера ![alt|400](src) / ![|400](src):
+       часть после "|" — ширина показа в px. */ -}}
+{{- $alt := .Text -}}
+{{- $maxw := 0 -}}
+{{- if strings.Contains $alt "|" -}}
+  {{- $parts := split $alt "|" -}}
+  {{- $alt = index $parts 0 -}}
+  {{- $size := index $parts (sub (len $parts) 1) -}}
+  {{- with (findRE "^[0-9]+" $size) -}}
+    {{- $maxw = int (index . 0) -}}
+  {{- end -}}
+{{- end -}}
 {{- partial "responsive-img.html" (dict
   "src" .Destination
-  "alt" .Text
+  "alt" $alt
   "title" .Title
+  "maxw" $maxw
 ) -}}

--- a/site/layouts/partials/responsive-img.html
+++ b/site/layouts/partials/responsive-img.html
@@ -1,15 +1,19 @@
 {{- /* Адаптивная картинка с оптимизацией (#1). Принимает dict:
-       src (обяз.), alt, title, class, id, loading (по умолч. lazy), sizes.
+       src (обяз.), alt, title, class, id, loading (по умолч. lazy), sizes,
+       maxw (ширина показа в px — из obsidian-синтаксиса ![|400]).
        Локальные растры (png/jpg/webp) режет под ширину показа, отдаёт WebP +
        srcset + width/height (против CLS) + data-zoom-src покрупнее для
-       medium-zoom. GIF/SVG/удалённые — отдаёт как есть. */ -}}
+       medium-zoom. GIF/SVG/удалённые — отдаёт как есть. Класс content-img
+       гарантирует height:auto + max-width:100% (против растягивания). */ -}}
 {{- $src := .src -}}
 {{- $alt := .alt | default "" -}}
 {{- $title := .title -}}
-{{- $class := .class -}}
+{{- $class := trim (printf "content-img %s" (.class | default "")) " " -}}
 {{- $id := .id -}}
 {{- $loading := .loading | default "lazy" -}}
-{{- $sizes := .sizes | default "(max-width: 760px) 92vw, 700px" -}}
+{{- $maxw := int (.maxw | default 0) -}}
+{{- $sizes := .sizes | default (cond (gt $maxw 0) (printf "%dpx" $maxw) "(max-width: 760px) 92vw, 700px") -}}
+{{- $style := cond (gt $maxw 0) (printf "width:%dpx" $maxw) "" -}}
 {{- $ext := lower (strings.TrimPrefix "." (path.Ext $src)) -}}
 {{- $isLocal := and (hasPrefix $src "/") (not (hasPrefix $src "//")) -}}
 {{- $raster := in (slice "png" "jpg" "jpeg" "webp") $ext -}}
@@ -43,8 +47,9 @@
     {{- if gt (len $variants) 1 }} srcset="{{ delimit $srcset ", " }}" sizes="{{ $sizes }}"{{ end }}
     width="{{ $fallback.Width }}"
     height="{{ $fallback.Height }}"
-    {{- with $class }} class="{{ . }}"{{ end }}
+    class="{{ $class }}"
     {{- with $id }} id="{{ . }}"{{ end }}
+    {{- with $style }} style="{{ . | safeCSS }}"{{ end }}
     alt="{{ $alt }}"
     {{- with $title }} title="{{ . }}"{{ end }}
     loading="{{ $loading }}"
@@ -52,5 +57,5 @@
     data-zoom-src="{{ $largest.RelPermalink }}"
   />
 {{- else -}}
-  <img src="{{ $src }}"{{ with $class }} class="{{ . }}"{{ end }}{{ with $id }} id="{{ . }}"{{ end }} alt="{{ $alt }}"{{ with $title }} title="{{ . }}"{{ end }} loading="{{ $loading }}" decoding="async" />
+  <img src="{{ $src }}" class="{{ $class }}"{{ with $id }} id="{{ . }}"{{ end }}{{ with $style }} style="{{ . | safeCSS }}"{{ end }} alt="{{ $alt }}"{{ with $title }} title="{{ . }}"{{ end }} loading="{{ $loading }}" decoding="async" />
 {{- end -}}


### PR DESCRIPTION
Fix stretched, oversized images in poems (#1 regression)

After the image pipeline landed, images in poems rendered full-container-wide
and vertically stretched. Two causes:

- The render hook set an explicit height attribute, but poetry images have no
  height:auto rule (only `article img` does), so the height was honored and
  the aspect ratio broke.
- The Obsidian width syntax `![|400](src)` (display the image at 400px) was
  dropped — the "|400" just landed in alt — so every image filled the
  container instead of its intended width.

- Parse `![alt|400]` / `![|400]` in the render hook and pass the width to the
  partial as a display width (inline width + matching sizes).
- Add a `content-img` class on every partial image with
  `max-width:100%; height:auto`, so aspect ratio holds everywhere, not just
  in articles.

Verified in a real browser (production build):
- turk: 640x668 stretched -> 300x278, correct aspect
- kintsugi (|400): 400px desktop, shrinks to 328px on a 360px screen, no distortion
- article images unchanged (full width, correct aspect)
