### PR TITLE
Show shortcut hint as a hover tooltip, not an inline badge

### DIFF
--- a/site/assets/main.js
+++ b/site/assets/main.js
@@ -257,7 +257,9 @@ const shortcutsMap = Object.fromEntries(
 );
 
 // Подсказка шортката при наведении на кнопки разделов (#29).
-// Сопоставляем ссылки навигации с шорткатами по их URL и вешаем бейдж с клавишей.
+// Сопоставляем ссылки навигации с шорткатами по URL и вешаем всплывающее
+// облачко (CSS-тултип через data-hint) — оно position:absolute и не влияет на
+// раскладку, поэтому пункты меню не разъезжаются.
 const normalizePath = (path) => {
   try {
     path = new URL(path, window.location.origin).pathname;
@@ -267,10 +269,10 @@ const normalizePath = (path) => {
   return path === "/" ? "/" : path.replace(/\/$/, "");
 };
 
-const urlToShortcutKey = Object.fromEntries(
+const urlToShortcut = Object.fromEntries(
   shortcuts
     .filter((s) => s.url)
-    .map((s) => [normalizePath(s.url), s.key]),
+    .map((s) => [normalizePath(s.url), s]),
 );
 
 function decorateShortcutHints() {
@@ -278,11 +280,12 @@ function decorateShortcutHints() {
   document.querySelectorAll(".side-menu a, .link a").forEach((a) => {
     const href = a.getAttribute("href");
     if (!href) return;
-    const key = urlToShortcutKey[normalizePath(href)];
-    if (!key) return;
+    const sc = urlToShortcut[normalizePath(href)];
+    if (!sc) return;
+    const desc = sc.description.charAt(0).toLowerCase() + sc.description.slice(1);
     a.classList.add("has-shortcut");
-    a.dataset.shortcut = key;
-    a.setAttribute("title", `Shortcut: ${key}`);
+    a.dataset.hint = `Press ${sc.key.toUpperCase()} to ${desc}`;
+    a.setAttribute("aria-keyshortcuts", sc.key);
   });
 }
 

--- a/site/assets/style.css
+++ b/site/assets/style.css
@@ -1994,31 +1994,37 @@ pre code * .err {
   font-size: 18px;
 }
 
-/* Подсказка клавиши-шортката при наведении на кнопку раздела (#29) */
-.side-menu a.has-shortcut,
-.link a.has-shortcut {
+/* Подсказка-шортката при наведении на кнопку раздела (#29): серое всплывающее
+   облачко над пунктом. position:absolute — не влияет на раскладку меню. */
+.has-shortcut {
   position: relative;
 }
-.side-menu a.has-shortcut::after,
-.link a.has-shortcut::after {
-  content: attr(data-shortcut);
-  display: inline-block;
-  margin-left: 0.5em;
-  padding: 0 0.4em;
-  border: 1px solid currentColor;
-  border-radius: 4px;
+.has-shortcut::after {
+  content: attr(data-hint);
+  position: absolute;
+  left: 0;
+  bottom: calc(100% + 6px);
+  z-index: 50;
+  background: #333;
+  color: #fff;
   font-family: monospace;
-  font-size: 0.75em;
-  line-height: 1.5;
-  vertical-align: middle;
+  font-size: 12px;
+  line-height: 1.4;
+  white-space: nowrap;
+  padding: 4px 8px;
+  border-radius: 6px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
   opacity: 0;
-  transition: opacity 0.15s ease;
+  transform: translateY(4px);
+  pointer-events: none;
+  transition:
+    opacity 0.15s ease,
+    transform 0.15s ease;
 }
-.side-menu a.has-shortcut:hover::after,
-.side-menu a.has-shortcut:focus-visible::after,
-.link a.has-shortcut:hover::after,
-.link a.has-shortcut:focus-visible::after {
-  opacity: 0.6;
+.has-shortcut:hover::after,
+.has-shortcut:focus-visible::after {
+  opacity: 0.97;
+  transform: translateY(0);
 }
 
 .overlay {


### PR DESCRIPTION
Show shortcut hint as a hover tooltip, not an inline badge (#29)

The previous inline key badge (::after) occupied layout even at opacity:0,
so the menu items spread apart.

Replace it with a gray tooltip bubble that pops above the menu item on
hover/focus, with descriptive text ("Press B to go to book shelf"):
- main.js sets data-hint from the shortcut's key + description, plus
  aria-keyshortcuts for accessibility
- the tooltip is position:absolute (pointer-events:none), so it no longer
  affects the menu layout

Verified in a real browser: the link box equals its text width (no spread),
and on hover the gray (#333) bubble appears above the item with the hint.
