### PR TITLE
Widen poem comments to match articles/essays

### DIFF
--- a/site/assets/style.css
+++ b/site/assets/style.css
@@ -545,12 +545,26 @@ p code * {
   justify-content: center;
 }
 
+/* Комментарии и разделители под стихом — той же ширины, что под статьями/эссе
+   (article: width 50% / min-width 700px, на мобиле 100%). Стих остаётся узким,
+   а блок комментариев под сгибом шире. */
+.verse-container #remark42,
+.verse-container hr {
+  width: 50%;
+  min-width: 700px;
+}
 .verse-container #remark42 {
-  width: 100%;
   /* Резервируем место под виджет комментариев (#33): он лениво подгружается и
      без брони на ~316px дёргает layout, когда iframe вставляется при скролле.
      Пустой виджет ≈ 311px; пишущих под стихами комментариев почти нет. */
   min-height: 320px;
+}
+@media (max-width: 650px) {
+  .verse-container #remark42,
+  .verse-container hr {
+    width: 100%;
+    min-width: unset;
+  }
 }
 
 .poetry {


### PR DESCRIPTION
The poem stays narrow and centered, but now that comments sit below the fold there is no reason to keep them at the poem width. `#remark42` and its framing `<hr>`s now use the same width as article/essay comments — 50%% / min-width 700px on desktop, full width below 650px.

### Verification (real browser)
- desktop 1280px: comments 700px — matches an articles page
- mobile 390px: full width (358px), no horizontal overflow